### PR TITLE
Fix systemd restart

### DIFF
--- a/systemd-udev/ipp-usb.service
+++ b/systemd-udev/ipp-usb.service
@@ -5,5 +5,5 @@ After=cups.service avahi-daemon.service
 Wants=avahi-daemon.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/sbin/ipp-usb udev


### PR DESCRIPTION
By my mistake in #10 , the systemd unit type was set wrongly in `systemd-udev/ipp-usb.service`, and service restart is broken.

Therefore, setting `Type=simple` there should fix this. Thanks got to Jindřich Makovička for identifying the bug.

See the Debian bug in: https://bugs.debian.org/973951