### PR TITLE
Add quirk to deny certain device capabilities

### DIFF
--- a/quirks.go
+++ b/quirks.go
@@ -28,13 +28,15 @@ type Quirks struct {
 	HttpHeaders      map[string]string // HTTP header override
 	UsbMaxInterfaces uint              // Max number of USB interfaces
 	Index            int               // Incremented in order of loading
+	BlacklistCaps    UsbIppBasicCaps   // Blacklist device capabilities using mask
 }
 
 // empty returns true, if Quirks are actually empty
 func (q *Quirks) empty() bool {
 	return !q.Blacklist &&
 		len(q.HttpHeaders) == 0 &&
-		q.UsbMaxInterfaces == 0
+		q.UsbMaxInterfaces == 0 &&
+		q.BlacklistCaps == 0
 }
 
 // QuirksSet represents collection of quirks, indexed by model name
@@ -120,6 +122,7 @@ func (qset *QuirksSet) readFile(file string) error {
 			continue
 		}
 
+		var tmpuint uint
 		switch rec.Key {
 		case "blacklist":
 			err = confLoadBinaryKey(&q.Blacklist, rec,
@@ -128,7 +131,12 @@ func (qset *QuirksSet) readFile(file string) error {
 		case "usb-max-interfaces":
 			err = confLoadUintKeyRange(&q.UsbMaxInterfaces, rec,
 				1, math.MaxUint32)
+
+		case "blacklist-caps":
+			err = confLoadUintKeyRange(&tmpuint, rec,
+				0, math.MaxUint32)
 		}
+		q.BlacklistCaps = UsbIppBasicCaps(tmpuint)
 	}
 
 	if err == io.EOF {

--- a/usbtransport.go
+++ b/usbtransport.go
@@ -70,6 +70,11 @@ func NewUsbTransport(desc UsbDeviceDesc) (*UsbTransport, error) {
 	// Setup quirks
 	transport.quirks = Conf.Quirks.Get(transport.info.MfgAndProduct)
 
+	// Remove blacklisted basic caps
+	for _, quirks := range transport.quirks {
+		transport.info.BasicCaps &^= quirks.BlacklistCaps
+	}
+
 	// Write device info to the log
 	log := transport.log.Begin().
 		Nl(LogDebug).
@@ -89,6 +94,7 @@ func NewUsbTransport(desc UsbDeviceDesc) (*UsbTransport, error) {
 		log.Debug(' ', "  from [%s] (%s)", quirks.Model, quirks.Origin)
 		log.Debug(' ', "    blacklist = %v", quirks.Blacklist)
 		log.Debug(' ', "    usb-max-interfaces = %v", quirks.UsbMaxInterfaces)
+		log.Debug(' ', "    blacklist-caps = %s", quirks.BlacklistCaps)
 		for name, value := range quirks.HttpHeaders {
 			log.Debug(' ', "    http-%s = %q", strings.ToLower(name), value)
 		}


### PR DESCRIPTION
Most devices annouce a whole set of capabilities print,scan,fax
and users wants to choose to disable some of them because their
either broken or some other reason.

It fixes an issue where ipp-usb would reset a device usb connection
every few seconds because one of the caps is broken on the device.


Example deny print and fax to keep only scan 
```
[HP Photosmart 6520 series]
  blacklist-caps = 5
```