### PR TITLE
Support reading quirks from /etc/ipp-usb

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -82,6 +82,7 @@ func ConfLoad() error {
 	// Load quirks
 	quirksDirs := []string{
 		PathQuirksDir,
+    PathConfQuirksDir,
 		filepath.Join(exepath, "ipp-usb-quirks"),
 	}
 

--- a/ipp-usb.8
+++ b/ipp-usb.8
@@ -1,75 +1,50 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "IPP\-USB" "8" "February 2021" "" "ipp-usb.8"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "IPP\-USB" "8" "March 2022" "" "ipp-usb.8"
 .SH "NAME"
 \fBipp\-usb\fR \- Daemon for IPP over USB printer support
-.
 .SH "DESCRIPTION"
 \fBipp\-usb\fR daemon enables driver\-less printing and scanning on USB\-only AirPrint\-compatible printers and MFPs\.
-.
 .P
 It works by connecting to the device by USB using IPP\-over\-USB protocol, and exposing the device to the network, including DNS\-SD (ZeroConf) advertising\.
-.
 .P
 IPP printing, eSCL scanning and web console are fully supported\.
-.
 .SH "SYNOPSIS"
-.
 .SS "Usage:"
 \fBipp\-usb mode [options]\fR
-.
 .SS "Modes are:"
-.
 .TP
 \fBstandalone\fR
 run forever, automatically discover IPP\-over\-USB devices and serve them all
-.
 .TP
 \fBudev\fR
 like standalone, but exit when last IPP\-over\-USB device is disconnected
-.
 .TP
 \fBdebug\fR
 logs duplicated on console, \-bg option is ignored
-.
 .TP
 \fBcheck\fR
 check configuration and exit
-.
 .SS "Options are"
-.
 .TP
 \fB\-bg\fR
 run in background (ignored in debug mode)
-.
 .SH "CONFIGURATION"
 \fBipp\-usb\fR searched for its configuration file in two places: 1\. \fB/etc/ipp\-usb/ipp\-usb\.conf\fR 2\. \fBipp\-usb\.conf\fR in the directory where executable file is located
-.
 .P
 Configuration file syntax is very similar to \.INI files syntax\. It consist of named sections, and each section contains a set of named variables\. Comments are started from # or ; characters and continues until end of line:
-.
 .IP "" 4
-.
 .nf
-
 # This is a comment
 [section 1]
 variable 1 = value 1  ; and another comment
 variable 2 = value 2
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Network parameters"
 Network parameters are all in the \fB[network]\fR section:
-.
 .IP "" 4
-.
 .nf
-
 [network]
   # TCP ports for HTTP will be automatically allocated in the following range
   http\-min\-port = 60000
@@ -86,18 +61,12 @@ Network parameters are all in the \fB[network]\fR section:
 
   # Enable or disable IPv6
   ipv6 = enable        # enable | disable
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Logging configuration"
 Logging parameters are all in the \fB[logging]\fR section:
-.
 .IP "" 4
-.
 .nf
-
 [logging]
   # device\-log  \- what logs are generated per device
   # main\-log    \- what common logs are generated
@@ -127,18 +96,12 @@ Logging parameters are all in the \fB[logging]\fR section:
 
   # Enable or disable ANSI colors on console
   console\-color = enable # enable | disable
-.
 .fi
-.
 .IP "" 0
-.
 .SS "Quirks"
-Some devices, due to their firmware bugs, require special handling, called device\-specific \fBquirks\fR\. \fBipp\-usb\fR loads quirks from the \fB/usr/share/ipp\-usb/quirks/*\.conf\fR files\. These files have \.INI\-file syntax with the content that looks like this:
-.
+Some devices, due to their firmware bugs, require special handling, called device\-specific \fBquirks\fR\. \fBipp\-usb\fR loads quirks from the \fB/usr/share/ipp\-usb/quirks/*\.conf\fR files and from the \fB/etc/ipp\-usb/quirks/*\.conf\fR files\. The \fB/etc/ipp\-usb/quirks\fR directory is for system quirks overrides or admin changes\. These files have \.INI\-file syntax with the content that looks like this:
 .IP "" 4
-.
 .nf
-
 [HP LaserJet MFP M28\-M31]
   http\-connection = keep\-alive
 
@@ -151,73 +114,53 @@ Some devices, due to their firmware bugs, require special handling, called devic
 # Default configuration
 [*]
   http\-connection = ""
-.
 .fi
-.
 .IP "" 0
-.
 .P
-For each discovered device, its model name is matched against sections of the quirks files\. Section name may contain glob\-style wildcards: \fB*\fR that matches any sequence of characters and \fB?\fR, that matches any single character\. To match one of these characters (\fB*\fR and \fB?\fR) literally, use backslash as escape\.
-.
+For each discovered device, its model name is matched against sections of the quirks files\. The section name contains an exact model name, which contains \fBiManufacturer\fR+\fBiProduct\fR entries from \fBlsusb \-v\fR command output, or it may contain glob\-style wildcards: \fB*\fR that matches any sequence of characters and \fB?\fR , that matches any single character\. To match one of these characters (\fB*\fR and \fB?\fR) literally, use backslash as escape\.
 .P
 All matching sections from all quirks files are taken in consideration, and applied in priority order\. Priority is computed using the following algorithm:
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 When matching model name against section name, amount of non\-wildcard matched characters is counted, and the longer match wins
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Otherwise, section loaded first wins\. Files are loaded in alphabetical order, sections read sequentially
-.
 .IP "" 0
-.
 .P
 If some parameter exist in multiple sections, used its value from the most priority section
-.
 .P
 The following parameters are defined:
-.
 .TP
 \fBblacklist = true | false\fR
 If \fBtrue\fR, the matching device is ignored by the \fBipp\-usb\fR
-.
 .TP
 \fBhttp\-XXX = YYY\fR
 Set XXX header of the HTTP requests forwarded to device to YYY\. If YYY is empty string, XXX header is removed
-.
 .TP
 \fBusb\-max\-interfaces = N\fR
 Don\'t use more that N USB interfaces, even if more is available
-.
+.P
+In case of you found out about your device needs a quirk to work properly or it does not work with \fBipp\-usb\fR at all, although it provides IPP\-over\-USB interface, please report the isues at https://github\.com/OpenPrinting/ipp\-usb\. The possible quirk for the device can be added to the project itself and fix the situation for all device\'s owners\.
 .SH "FILES"
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/etc/ipp\-usb/ipp\-usb\.conf\fR: the daemon configuration file
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/var/log/ipp\-usb/main\.log\fR: the main log file
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/var/log/ipp\-usb/<DEVICE>\.log\fR: per\-device log files
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/var/ipp\-usb/dev/<DEVICE>\.state\fR: device state (HTTP port allocation, DNS\-SD name)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/var/ipp\-usb/lock/ipp\-usb\.lock\fR: lock file, that helps to prevent multiple copies of daemon to run simultaneously
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB/usr/share/ipp\-usb/quirks/*\.conf\fR: device\-specific quirks (see above)
-.
+.IP "\[ci]" 4
+\fB/etc/ipp\-usb/quirks/*\.conf\fR: device\-specific quirks defined by sysadmin (see above)
 .IP "" 0
-.
 .SH "COPYRIGHT"
 Copyright (c) by Alexander Pevzner (pzz@apevzner\.com)
-.
 .br
 All rights reserved\.
-.
 .P
 This program is licensed under 2\-Clause BSD license\. See LICENSE file for details\.
-.
 .SH "SEE ALSO"
 cups(1)

--- a/ipp-usb.8.md
+++ b/ipp-usb.8.md
@@ -114,8 +114,9 @@ Logging parameters are all in the `[logging]` section:
 
 Some devices, due to their firmware bugs, require special handling,
 called device-specific **quirks**. `ipp-usb` loads quirks from the
-`/usr/share/ipp-usb/quirks/*.conf` files. These files have .INI-file
-syntax with the content that looks like this:
+`/usr/share/ipp-usb/quirks/*.conf` files and from the `/etc/ipp-usb/quirks/*.conf`
+files. The `/etc/ipp-usb/quirks` directory is for system quirks overrides or
+admin changes. These files have .INI-file syntax with the content that looks like this:
 
     [HP LaserJet MFP M28-M31]
       http-connection = keep-alive
@@ -131,9 +132,10 @@ syntax with the content that looks like this:
       http-connection = ""
 
 For each discovered device, its model name is matched against sections
-of the quirks files. Section name may contain glob-style wildcards: `*` that
-matches any sequence of characters and `?`, that matches any single
-character. To match one of these characters (`*` and `?`) literally,
+of the quirks files. The section name contains an exact model name,
+which contains `iManufacturer`+`iProduct` entries from `lsusb -v` command output,
+or it may contain glob-style wildcards: `*` that matches any sequence of characters and `?`
+, that matches any single character. To match one of these characters (`*` and `?`) literally,
 use backslash as escape.
 
 All matching sections from all quirks files are taken in consideration,
@@ -160,6 +162,12 @@ The following parameters are defined:
    * `usb-max-interfaces = N`:
      Don't use more that N USB interfaces, even if more is available
 
+In case of you found out about your device needs a quirk to work properly
+or it does not work with `ipp-usb` at all, although it provides IPP-over-USB
+interface, please report the isues at https://github.com/OpenPrinting/ipp-usb.
+The possible quirk for the device can be added to the project itself
+and fix the situation for all device's owners.
+
 ## FILES
 
    * `/etc/ipp-usb/ipp-usb.conf`:
@@ -178,6 +186,8 @@ The following parameters are defined:
      lock file, that helps to prevent multiple copies of daemon to run simultaneously
 
    * `/usr/share/ipp-usb/quirks/*.conf`: device-specific quirks (see above)
+
+   * `/etc/ipp-usb/quirks/*.conf`: device-specific quirks defined by sysadmin (see above)
 
 ## COPYRIGHT
 

--- a/paths.go
+++ b/paths.go
@@ -12,6 +12,9 @@ const (
 	// PathConfDir defines path to configuration directory
 	PathConfDir = "/etc/ipp-usb"
 
+	// PathConfQuirksDir defines path to quirks files in configuration directory
+	PathConfQuirksDir = "/etc/ipp-usb/quirks"
+
 	// PathQuirksDir defines path to quirks files
 	PathQuirksDir = "/usr/share/ipp-usb/quirks"
 


### PR DESCRIPTION
`ipp-usb` now looks into /etc/ipp-usb/quirks as well, where admin
configuration quirks can lie. They will be read after system ones, so
the priority is set by sequence in conf.go.

Mentioned what model name is in quirk files + asked for reports about
quirks, so they can be added into system quirks if possible.