### PR TITLE
Fixed crash on ipp-usb status

### DIFF
--- a/status.go
+++ b/status.go
@@ -74,6 +74,7 @@ func StatusFormat() []byte {
 	i := 0
 	for _, status := range statusTable {
 		devs[i] = status
+		i++
 	}
 
 	sort.Slice(devs, func(i, j int) bool {


### PR DESCRIPTION
If multiple devices are present, "ipp-usb status" crashes, due to a missing increment of a loop counter. This patch fixes the issue