### PR TITLE
Added tcp port info to status output

### DIFF
--- a/pnp.go
+++ b/pnp.go
@@ -83,7 +83,7 @@ loop:
 			for _, addr := range added {
 				Log.Debug('+', "PNP %s: added", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], err)
+				StatusSet(addr, devDescs[addr], err, dev.State.HTTPPort)
 
 				if err == nil {
 					devByAddr[addr] = dev
@@ -114,7 +114,7 @@ loop:
 
 				Log.Debug('+', "PNP %s: retry", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], err)
+				StatusSet(addr, devDescs[addr], err, dev.State.HTTPPort)
 
 				if err == nil {
 					devByAddr[addr] = dev

--- a/pnp.go
+++ b/pnp.go
@@ -83,7 +83,7 @@ loop:
 			for _, addr := range added {
 				Log.Debug('+', "PNP %s: added", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], err, dev.State.HTTPPort)
+				StatusSet(addr, devDescs[addr], dev.State.HTTPPort, err)
 
 				if err == nil {
 					devByAddr[addr] = dev
@@ -114,7 +114,7 @@ loop:
 
 				Log.Debug('+', "PNP %s: retry", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], err, dev.State.HTTPPort)
+				StatusSet(addr, devDescs[addr], dev.State.HTTPPort, err)
 
 				if err == nil {
 					devByAddr[addr] = dev

--- a/status.go
+++ b/status.go
@@ -22,6 +22,7 @@ import (
 type statusOfDevice struct {
 	desc UsbDeviceDesc // Device descriptor
 	init error         // Initialization error, nil if none
+	HTTPPort int       // Assigned http port for the device
 }
 
 var (
@@ -87,20 +88,20 @@ func StatusFormat() []byte {
 		buf.WriteString(" not found\n")
 	} else {
 		buf.WriteString("\n")
-		fmt.Fprintf(buf, " Num  Device              Vndr:Prod  Model\n")
+		fmt.Fprintf(buf, " Num  Device              Vndr:Prod  Port  Model\n")
 		for i, status := range devs {
 			info, _ := status.desc.GetUsbDeviceInfo()
 
-			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %q\n",
+			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %d %-32q",
 				i+1, status.desc.UsbAddr,
-				info.Vendor, info.Product, info.MfgAndProduct)
+				info.Vendor, info.Product, status.HTTPPort, info.MfgAndProduct)
 
 			s := "OK"
 			if status.init != nil {
 				s = devs[i].init.Error()
 			}
 
-			fmt.Fprintf(buf, "      status: %s", s)
+			fmt.Fprintf(buf, " status: %s\n", s)
 		}
 	}
 
@@ -109,11 +110,12 @@ func StatusFormat() []byte {
 
 // StatusSet adds device to the status table or updates status
 // of the already known device
-func StatusSet(addr UsbAddr, desc UsbDeviceDesc, init error) {
+func StatusSet(addr UsbAddr, desc UsbDeviceDesc, init error, HTTPPort int) {
 	statusLock.Lock()
 	statusTable[addr] = &statusOfDevice{
 		desc: desc,
 		init: init,
+		HTTPPort: HTTPPort,
 	}
 	statusLock.Unlock()
 }

--- a/status.go
+++ b/status.go
@@ -92,7 +92,7 @@ func StatusFormat() []byte {
 		for i, status := range devs {
 			info, _ := status.desc.GetUsbDeviceInfo()
 
-			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %d %-32q",
+			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %d %q\n",
 				i+1, status.desc.UsbAddr,
 				info.Vendor, info.Product, status.HTTPPort, info.MfgAndProduct)
 
@@ -110,7 +110,7 @@ func StatusFormat() []byte {
 
 // StatusSet adds device to the status table or updates status
 // of the already known device
-func StatusSet(addr UsbAddr, desc UsbDeviceDesc, init error, HTTPPort int) {
+func StatusSet(addr UsbAddr, desc UsbDeviceDesc, HTTPPort int, init error) {
 	statusLock.Lock()
 	statusTable[addr] = &statusOfDevice{
 		desc: desc,

--- a/status.go
+++ b/status.go
@@ -74,6 +74,7 @@ func StatusFormat() []byte {
 	i := 0
 	for _, status := range statusTable {
 		devs[i] = status
+		i++
 	}
 
 	sort.Slice(devs, func(i, j int) bool {


### PR DESCRIPTION
It would be very helpful to see the number of the assigned tcp port for each device on using "ipp-usb status".
This patch adds the tcp port to the status output.

```
$ ./ipp-usb status
ipp-usb daemon: running
ipp-usb devices:
 Num  Device              Vndr:Prod  Port  Model
   1. Bus 001 Device 039  04a9:1912  60100 "Canon LiDE 400"                 status: OK
```