### PR TITLE
Fixed crash with blacklisted devices

### DIFF
--- a/pnp.go
+++ b/pnp.go
@@ -83,7 +83,11 @@ loop:
 			for _, addr := range added {
 				Log.Debug('+', "PNP %s: added", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], dev.State.HTTPPort, err)
+				port := 0
+				if dev != nil {
+					port = dev.State.HTTPPort
+				}
+				StatusSet(addr, devDescs[addr], port, err)
 
 				if err == nil {
 					devByAddr[addr] = dev
@@ -114,7 +118,11 @@ loop:
 
 				Log.Debug('+', "PNP %s: retry", addr)
 				dev, err := NewDevice(devDescs[addr])
-				StatusSet(addr, devDescs[addr], dev.State.HTTPPort, err)
+				port := 0
+				if dev != nil {
+					port = dev.State.HTTPPort
+				}
+				StatusSet(addr, devDescs[addr], port, err)
 
 				if err == nil {
 					devByAddr[addr] = dev


### PR DESCRIPTION
Unfortunately, the last patch crashes the daemon when a blacklisted device is detected.
In this case `dev.State.HTTPPort` cannot be accessed, because `dev` is `nil`.
This patch fixes the issue.

