### PR TITLE
Print '-' instead of '0' on zero port numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ ifeq ($(PREFIX),/)
         PREFIX :=
 endif
 
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
+
 all:
 	-gotags -R . > tags
-	go build -ldflags "-s -w" -tags nethttpomithttp2 -mod=vendor
+	go build -ldflags "-s -w -X 'main.Version=$(VERSION)'" -tags nethttpomithttp2 -mod=vendor
 
 man:	$(MANPAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(PREFIX),/)
         PREFIX :=
 endif
 
-VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
+VERSION := $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || echo dev)
 
 all:
 	-gotags -R . > tags

--- a/main.go
+++ b/main.go
@@ -15,10 +15,13 @@ import (
 	"sort"
 )
 
+var Version = "dev"
+
 const usageText = `Usage:
     %s mode [options]
 
 Modes are:
+    version     - display version number and exit
     standalone  - run forever, automatically discover IPP-over-USB
                   devices and serve them all
     udev        - like standalone, but exit when last IPP-over-USB
@@ -50,6 +53,7 @@ const (
 	RunDebug
 	RunCheck
 	RunStatus
+	RunVersion
 )
 
 // String returns RunMode name
@@ -67,6 +71,8 @@ func (m RunMode) String() string {
 		return "check"
 	case RunStatus:
 		return "status"
+	case RunVersion:
+		return "version"
 	}
 
 	return fmt.Sprintf("unknown (%d)", int(m))
@@ -127,6 +133,9 @@ func parseArgv() (params RunParameters) {
 			modes++
 		case "status":
 			params.Mode = RunStatus
+			modes++
+		case "version":
+			params.Mode = RunVersion
 			modes++
 		case "-bg":
 			params.Background = true
@@ -194,6 +203,12 @@ func main() {
 	Log.SetLevels(Conf.LogMain)
 	Console.SetLevels(Conf.LogConsole)
 	Log.Cc(Console)
+	
+	// In RunVersion mode, display version number
+	if params.Mode == RunVersion {
+		InitLog.Info(0, "ipp-usb daemon %s", Version)
+		os.Exit(0)
+	}
 
 	// In RunCheck mode, list IPP-over-USB devices
 	if params.Mode == RunCheck {

--- a/status.go
+++ b/status.go
@@ -67,7 +67,7 @@ func StatusFormat() []byte {
 
 	// Dump ipp-usb daemon status. If we are here, we are
 	// definitely running :-)
-	buf.WriteString("ipp-usb daemon: running\n")
+	fmt.Fprintf(buf, "ipp-usb daemon %s: running\n", Version)
 
 	// Sort devices by address
 	devs := make([]*statusOfDevice, len(statusTable))
@@ -92,15 +92,9 @@ func StatusFormat() []byte {
 		for i, status := range devs {
 			info, _ := status.desc.GetUsbDeviceInfo()
 
-			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %-5s %q\n",
+			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %-5d %q\n",
 				i+1, status.desc.UsbAddr,
-				info.Vendor, info.Product,
-				func() string {
-					if status.HTTPPort == 0 {
-						return "-"
-					}
-					return fmt.Sprintf("%d", status.HTTPPort)
-				}(),
+				info.Vendor, info.Product, status.HTTPPort,
 				info.MfgAndProduct)
 
 			s := "OK"

--- a/status.go
+++ b/status.go
@@ -92,9 +92,15 @@ func StatusFormat() []byte {
 		for i, status := range devs {
 			info, _ := status.desc.GetUsbDeviceInfo()
 
-			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %-5d %q\n",
+			fmt.Fprintf(buf, " %3d. %s  %4.4x:%.4x  %-5s %q\n",
 				i+1, status.desc.UsbAddr,
-				info.Vendor, info.Product, status.HTTPPort,
+				info.Vendor, info.Product,
+				func() string {
+					if status.HTTPPort == 0 {
+						return "-"
+					}
+					return fmt.Sprintf("%d", status.HTTPPort)
+				}(),
 				info.MfgAndProduct)
 
 			s := "OK"


### PR DESCRIPTION
If devices are blacklisted, the tcp port in the status output will no longer display '0', but '-' to increase readability.