### PR TITLE
Ensure printer-uri Adheres to RFC 3510 – Must Start with "ipp:" Scheme

### DIFF
--- a/ipp.go
+++ b/ipp.go
@@ -60,7 +60,7 @@ func IppService(log *LogMessage, services *DNSSdServices,
 		// not on device capabilities, lets leave it here
 		// for now, just in case. Firmwares in general are
 		// too buggy, I can't trust them :-(
-		uri = fmt.Sprintf("http://localhost:%d/ipp/faxout", port)
+		uri = fmt.Sprintf("ipp://localhost:%d/ipp/faxout", port)
 		_, _, err2 := ippGetPrinterAttributes(log, c, quirks, uri)
 
 		if err2 == nil {

--- a/ipp.go
+++ b/ipp.go
@@ -39,7 +39,7 @@ func IppService(log *LogMessage, services *DNSSdServices,
 	c *http.Client) (ippinfo *IppPrinterInfo, httpstatus int, err error) {
 
 	// Query printer attributes
-	uri := fmt.Sprintf("http://localhost:%d/ipp/print", port)
+	uri := fmt.Sprintf("ipp://localhost:%d/ipp/print", port)
 	msg, httpstatus, err := ippGetPrinterAttributes(log, c, quirks, uri)
 	if err != nil {
 		return


### PR DESCRIPTION
RFC 3510 - Internet Printing Protocol/1.1: IPP URL Scheme (https://www.rfc-editor.org/rfc/rfc3510.html)

   The IPP URL scheme syntax in ABNF is as follows:

   ipp-URL = "ipp:" "//" host [ ":" port ] [ abs_path [ "?" query ]]

## IPP Printer URL Examples

   The following are examples of well-formed IPP URLs for IPP Printers
   (for example, to be used as protocol elements in 'printer-uri'
   operation attributes of 'Print-Job' request messages):

      ipp://example.com
      ipp://example.com/printer
      ipp://example.com/printer/tiger
      ipp://example.com/printer/fox
      ipp://example.com/printer/tiger/bob
      ipp://example.com/printer/tiger/ira

   Each of the above URLs are well-formed URLs for IPP Printers and each
   would reference a logically different IPP Printer, even though some
   of those IPP Printers might share the same host system.  The 'bob' or
   'ira' last path components might represent two different physical
   printer devices, while 'tiger' might represent some grouping of IPP
   Printers (for example, a load-balancing spooler).  Or the 'bob' and
   'ira' last path components might represent separate human recipients
   on the same physical printer device (for example, a physical printer
   supporting two job queues).  In either case, both 'bob' and 'ira'
   would behave as different and independent IPP Printers.

   The following are examples of well-formed IPP URLs for IPP Printers
   with (optional) ports and paths:

      ipp://example.com
      ipp://example.com/~smith/printer
      ipp://example.com:631/~smith/printer

   The first and second IPP URLs above MUST be resolved to port 631
   (IANA assigned well-known port for IPP).  The second and third IPP
   URLs above are equivalent (see [section 4.7](https://www.rfc-editor.org/rfc/rfc3510.html#section-4.7) below).