### PR TITLE
correct typo in TestAddPDL error message

### DIFF
--- a/addpdl_test.go
+++ b/addpdl_test.go
@@ -66,7 +66,7 @@ func TestAddPDL(t *testing.T) {
 		}
 
 		if txt[0].Value != data.out {
-			t.Errorf("test %d: extected %q, got %q",
+			t.Errorf("test %d: expected %q, got %q",
 				i+1, data.out, txt[0].Value)
 		}
 	}


### PR DESCRIPTION
Fixed a typo in the error message inside TestAddPDL
Changed "extected" to "expected" for clarity

This improves test readability but does not affect functionality
Fixes #99 