### PR TITLE
correct typo in TestUUIDNormalize error message

### DIFF
--- a/addpdl_test.go
+++ b/addpdl_test.go
@@ -66,7 +66,7 @@ func TestAddPDL(t *testing.T) {
 		}
 
 		if txt[0].Value != data.out {
-			t.Errorf("test %d: extected %q, got %q",
+			t.Errorf("test %d: expected %q, got %q",
 				i+1, data.out, txt[0].Value)
 		}
 	}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -28,7 +28,7 @@ func TestUUIDNormalize(t *testing.T) {
 	for _, data := range testDataUUID {
 		uuid := UUIDNormalize(data.in)
 		if uuid != data.out {
-			t.Errorf("UUIDNormalize(%q): extected %q, got %q", data.in, data.out, uuid)
+			t.Errorf("UUIDNormalize(%q): expected %q, got %q", data.in, data.out, uuid)
 		}
 	}
 }


### PR DESCRIPTION
Fixed a typo in the TestUUIDNormalize function 
Changed "extected" to "expected" for clarity

This improves test readability but does not affect functionality