### PR TITLE
Duplicate manufacturer names (“Hewlett-Packard” + “HP”) appear in printer identifiers and DNS-SD; de-duplicate based on libcupsfilters logic.

### DIFF
--- a/usbcommon.go
+++ b/usbcommon.go
@@ -263,6 +263,12 @@ func (info UsbDeviceInfo) CheckMissed() error {
 // string
 func (info UsbDeviceInfo) MakeAndModel() string {
 	mfg := strings.TrimSpace(info.Manufacturer)
+
+	// Fix: Hewlett-Packard HP LaserJet 1020
+	if mfg == "Hewlett-Packard" {
+		mfg = "HP"
+	}
+
 	prod := strings.TrimSpace(info.ProductName)
 
 	makeModel := prod


### PR DESCRIPTION
Some HP printers have duplicated manufacturer names in multiple identifier fields, such as the full company name “Hewlett‑Packard” and its abbreviation “HP” appearing at the same time. This can cause recognition or matching issues.

Example:

```
Manufacturer:  Hewlett‑Packard
Product:       HP LaserJet 1020
Ieee1284ID:    MFG:Hewlett‑Packard;MDL:HP LaserJet 1020;CMD:ACL;CLS:PRINTER;DES:HP LaserJet 1020;FWVER:20080222;
```
```
DNS‑SD: Hewlett‑Packard HP LaserJet 1020
```
Proposed Fix / Reference:

https://github.com/OpenPrinting/libcupsfilters/blob/5d1b247a73dcd68d7bf155436d2865ddaec7601b/cupsfilters/ieee1284.c#L327