### PR TITLE
Remove HP X677 quirks

### DIFF
--- a/ipp-usb-quirks/HP.conf
+++ b/ipp-usb-quirks/HP.conf
@@ -49,16 +49,6 @@
   init-retry-partial = true
   zlp-recv-hack = true
 
-# HP X677 device sometimes fails on printing large raster jobs.
-# Looks like timing issue on firmware or hardware at the device
-# side.
-#
-# See the following link for details:
-#   https://github.com/OpenPrinting/ipp-usb/issues/95
-[*HP Color LaserJet Flow X677*]
-  usb-send-delay-threshold = 2048
-  usb-send-delay = 0.2ms
-
 # HP LaserJet M406 fails to initialize immediately after device
 # reboot and requires a lot of time to warm up.
 #


### PR DESCRIPTION
The firmware 5.9.0.2 (Aug 27, 2025) contains a proper fix.