### PR TITLE
Implements escl-auto-release quirk

### DIFF
--- a/http.go
+++ b/http.go
@@ -13,17 +13,40 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 var (
 	httpSessionID int32
 )
+
+const (
+	esclScanJobsPrefix           = "/eSCL/ScanJobs/"
+	esclScanJobsPath             = "/eSCL/ScanJobs"
+	esclNextDocumentSuffix       = "/NextDocument"
+	esclScannerCapabilitiesPath  = "/eSCL/ScannerCapabilities"
+	esclScannerStatusPath        = "/eSCL/ScannerStatus"
+	esclAutoReleasedJobMaxAge    = time.Hour
+	esclAutoReleasedJobLogFormat = "eSCL job %s already auto-released"
+)
+
+type esclPendingJob struct {
+	host string
+	when time.Time
+}
+
+type esclReleasingJob struct {
+	host string
+	done chan struct{}
+}
 
 // HTTPProxy represents HTTP protocol proxy backed by the
 // specified http.RoundTripper. It implements http.Handler
@@ -34,6 +57,11 @@ type HTTPProxy struct {
 	enable    bool          // Proxy can handle incoming requests
 	transport *UsbTransport // Transport for outgoing requests
 	closeWait chan struct{} // Closed at server close
+
+	esclAutoReleasedJobs      map[string]time.Time
+	esclAutoReleasedJobsMutex sync.Mutex
+	esclExhaustedJobs         map[string]esclPendingJob
+	esclReleasingJobs         map[string]esclReleasingJob
 }
 
 // NewHTTPProxy creates new HTTP proxy
@@ -41,9 +69,12 @@ func NewHTTPProxy(logger *Logger,
 	listener net.Listener, transport *UsbTransport) *HTTPProxy {
 
 	proxy := &HTTPProxy{
-		log:       logger,
-		transport: transport,
-		closeWait: make(chan struct{}),
+		log:                  logger,
+		transport:            transport,
+		closeWait:            make(chan struct{}),
+		esclAutoReleasedJobs: make(map[string]time.Time),
+		esclExhaustedJobs:    make(map[string]esclPendingJob),
+		esclReleasingJobs:    make(map[string]esclReleasingJob),
 	}
 
 	proxy.server = &http.Server{
@@ -177,12 +208,60 @@ func (proxy *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// If the escl-auto-release quirk has already released this scan job,
+	// satisfy the client's later DELETE locally.
+	if proxy.transport.Quirks().GetEsclAutoRelease() {
+		if r.Method == "DELETE" {
+			if proxy.takeAutoReleasedESCLJob(r.URL.Path) {
+				proxy.httpLocalStatus(session, w, r, http.StatusOK,
+					esclAutoReleasedJobLogFormat, r.URL.Path)
+				return
+			}
+
+			proxy.waitForReleasingESCLJob(r.URL.Path)
+			if proxy.takeAutoReleasedESCLJob(r.URL.Path) {
+				proxy.httpLocalStatus(session, w, r, http.StatusOK,
+					esclAutoReleasedJobLogFormat, r.URL.Path)
+				return
+			}
+
+			proxy.forgetExhaustedESCLJob(r.URL.Path)
+		}
+
+		if esclNeedsSynchronousExhaustedJobRelease(r) {
+			proxy.waitForReleasingESCLJobs()
+			proxy.autoReleaseExhaustedESCLJobs(session)
+		} else if !esclNeedsPostResponseExhaustedJobRelease(r) &&
+			r.Method != "DELETE" {
+			proxy.autoReleaseExhaustedESCLJobsAsync(session)
+		}
+	}
+
 	// Send request and obtain response status and header
 	resp, err := proxy.transport.RoundTripWithSession(session, r)
 	if err != nil {
 		proxy.httpError(session, w, r, http.StatusServiceUnavailable, err)
 		return
 	}
+
+	// Some clients fail to DELETE eSCL scan jobs after NextDocument
+	// returns 404. With the escl-auto-release quirk enabled, remember that
+	// this job is exhausted and release it if the client asks for scanner
+	// status or tries to start another scan without deleting it first.
+	if proxy.transport.Quirks().GetEsclAutoRelease() &&
+		resp.StatusCode == http.StatusNotFound {
+
+		jobPath := esclJobPathFromNextDocumentPath(r.URL.Path)
+		if r.Method == "GET" && jobPath != "" {
+			proxy.rememberExhaustedESCLJob(jobPath, r.Host)
+			proxy.log.HTTPDebug(' ', session,
+				"eSCL auto-release: remembered exhausted job %s",
+				jobPath)
+		}
+	}
+
+	releaseExhaustedAfterResponse := proxy.transport.Quirks().GetEsclAutoRelease() &&
+		esclNeedsPostResponseExhaustedJobRelease(r)
 
 	httpRemoveHopByHopHeaders(resp.Header)
 	httpCopyHeaders(w.Header(), resp.Header)
@@ -196,6 +275,295 @@ func (proxy *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Body.Close()
+
+	if releaseExhaustedAfterResponse {
+		proxy.autoReleaseExhaustedESCLJobsAsync(session)
+	}
+}
+
+// Respond to request locally with a status and no body.
+func (proxy *HTTPProxy) httpLocalStatus(session int, w http.ResponseWriter,
+	r *http.Request, status int, format string, args ...interface{}) {
+
+	proxy.log.Begin().
+		HTTPRqParams(LogDebug, '>', session, r).
+		HTTPRequest(LogTraceHTTP, '>', session, r).
+		Commit()
+
+	w.WriteHeader(status)
+
+	if format != "" {
+		proxy.log.HTTPDebug(' ', session, format, args...)
+	}
+}
+
+// autoReleaseESCLJob sends a synthetic DELETE for the eSCL scan job and
+// remembers successful releases, so a client DELETE that follows can still
+// receive 200 OK.
+func (proxy *HTTPProxy) autoReleaseESCLJob(session int, host, jobPath string) bool {
+	u := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   jobPath,
+	}
+
+	r, err := http.NewRequest("DELETE", u.String(), nil)
+	if err != nil {
+		proxy.log.HTTPError('!', session, "eSCL auto-release: %s", err)
+		return false
+	}
+
+	autoSession := int(atomic.AddInt32(&httpSessionID, 1)-1) % 1000
+	resp, err := proxy.transport.RoundTripWithSession(autoSession, r)
+	if err != nil {
+		proxy.log.HTTPError('!', session, "eSCL auto-release: %s", err)
+		return false
+	}
+
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	if err != nil {
+		proxy.log.HTTPError('!', autoSession, "%s", err)
+	}
+
+	resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		proxy.log.HTTPError('!', session, "eSCL auto-release: DELETE %s: %s",
+			jobPath, resp.Status)
+		return false
+	}
+
+	proxy.rememberAutoReleasedESCLJob(jobPath)
+	proxy.log.HTTPDebug(' ', session, "eSCL auto-release: DELETE %s: %s",
+		jobPath, resp.Status)
+
+	return true
+}
+
+// autoReleaseExhaustedESCLJobs releases all eSCL jobs known to have no more
+// documents, before handling requests that need the scanner to become idle.
+func (proxy *HTTPProxy) autoReleaseExhaustedESCLJobs(session int) {
+	jobs := proxy.takeExhaustedESCLJobsForRelease()
+	for jobPath, job := range jobs {
+		if !proxy.autoReleaseESCLJob(session, job.host, jobPath) {
+			proxy.rememberExhaustedESCLJob(jobPath, job.host)
+		}
+
+		proxy.finishReleasingESCLJob(jobPath)
+	}
+}
+
+// autoReleaseExhaustedESCLJobsAsync starts automatic release for all eSCL jobs
+// known to have no more documents, without blocking the client request.
+func (proxy *HTTPProxy) autoReleaseExhaustedESCLJobsAsync(session int) {
+	jobs := proxy.takeExhaustedESCLJobsForRelease()
+	if len(jobs) == 0 {
+		return
+	}
+
+	go func() {
+		defer func() {
+			v := recover()
+			if v != nil {
+				Log.Panic(v)
+			}
+		}()
+
+		for jobPath, job := range jobs {
+			if !proxy.autoReleaseESCLJob(session, job.host, jobPath) {
+				proxy.rememberExhaustedESCLJob(jobPath, job.host)
+			}
+
+			proxy.finishReleasingESCLJob(jobPath)
+		}
+	}()
+}
+
+// takeAutoReleasedESCLJob reports if path is a DELETE for a previously
+// auto-released eSCL scan job, and forgets it after it is consumed.
+func (proxy *HTTPProxy) takeAutoReleasedESCLJob(path string) bool {
+	if !esclJobPathValid(path) {
+		return false
+	}
+
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	proxy.cleanupAutoReleasedESCLJobs()
+
+	_, found := proxy.esclAutoReleasedJobs[path]
+	delete(proxy.esclAutoReleasedJobs, path)
+	return found
+}
+
+// rememberAutoReleasedESCLJob records a successfully auto-released eSCL job.
+func (proxy *HTTPProxy) rememberAutoReleasedESCLJob(path string) {
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	proxy.cleanupAutoReleasedESCLJobs()
+	proxy.esclAutoReleasedJobs[path] = time.Now()
+}
+
+// rememberExhaustedESCLJob records an eSCL job that returned 404 for
+// NextDocument, but has not been deleted by the client yet.
+func (proxy *HTTPProxy) rememberExhaustedESCLJob(path, host string) {
+	if !esclJobPathValid(path) {
+		return
+	}
+
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	proxy.cleanupAutoReleasedESCLJobs()
+	proxy.esclExhaustedJobs[path] = esclPendingJob{
+		host: host,
+		when: time.Now(),
+	}
+}
+
+// forgetExhaustedESCLJob cancels automatic release for a job that a client is
+// going to DELETE itself.
+func (proxy *HTTPProxy) forgetExhaustedESCLJob(path string) {
+	if !esclJobPathValid(path) {
+		return
+	}
+
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	delete(proxy.esclExhaustedJobs, path)
+}
+
+// takeExhaustedESCLJobsForRelease returns all known exhausted eSCL jobs,
+// clears them from the exhausted set, and marks them as releasing.
+func (proxy *HTTPProxy) takeExhaustedESCLJobsForRelease() map[string]esclReleasingJob {
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	proxy.cleanupAutoReleasedESCLJobs()
+
+	jobs := make(map[string]esclReleasingJob)
+	for path, job := range proxy.esclExhaustedJobs {
+		releasing := esclReleasingJob{
+			host: job.host,
+			done: make(chan struct{}),
+		}
+
+		jobs[path] = releasing
+		proxy.esclReleasingJobs[path] = releasing
+		delete(proxy.esclExhaustedJobs, path)
+	}
+
+	return jobs
+}
+
+// finishReleasingESCLJob marks an eSCL job synthetic release as finished.
+func (proxy *HTTPProxy) finishReleasingESCLJob(path string) {
+	proxy.esclAutoReleasedJobsMutex.Lock()
+	defer proxy.esclAutoReleasedJobsMutex.Unlock()
+
+	releasing := proxy.esclReleasingJobs[path]
+	delete(proxy.esclReleasingJobs, path)
+
+	if releasing.done != nil {
+		close(releasing.done)
+	}
+}
+
+// waitForReleasingESCLJob waits if this job is being released synthetically.
+func (proxy *HTTPProxy) waitForReleasingESCLJob(path string) {
+	if !esclJobPathValid(path) {
+		return
+	}
+
+	for {
+		proxy.esclAutoReleasedJobsMutex.Lock()
+		releasing := proxy.esclReleasingJobs[path]
+		proxy.esclAutoReleasedJobsMutex.Unlock()
+
+		if releasing.done == nil {
+			return
+		}
+
+		<-releasing.done
+	}
+}
+
+// waitForReleasingESCLJobs waits for all in-progress synthetic releases.
+func (proxy *HTTPProxy) waitForReleasingESCLJobs() {
+	for {
+		proxy.esclAutoReleasedJobsMutex.Lock()
+		done := make([]chan struct{}, 0, len(proxy.esclReleasingJobs))
+		for _, releasing := range proxy.esclReleasingJobs {
+			done = append(done, releasing.done)
+		}
+		proxy.esclAutoReleasedJobsMutex.Unlock()
+
+		if len(done) == 0 {
+			return
+		}
+
+		for _, ch := range done {
+			<-ch
+		}
+	}
+}
+
+// cleanupAutoReleasedESCLJobs drops old eSCL job records.
+func (proxy *HTTPProxy) cleanupAutoReleasedESCLJobs() {
+	now := time.Now()
+
+	for path, when := range proxy.esclAutoReleasedJobs {
+		if now.Sub(when) > esclAutoReleasedJobMaxAge {
+			delete(proxy.esclAutoReleasedJobs, path)
+		}
+	}
+
+	for path, job := range proxy.esclExhaustedJobs {
+		if now.Sub(job.when) > esclAutoReleasedJobMaxAge {
+			delete(proxy.esclExhaustedJobs, path)
+		}
+	}
+}
+
+// esclJobPathFromNextDocumentPath returns the scan job path for
+// /eSCL/ScanJobs/<id>/NextDocument requests, or an empty string otherwise.
+func esclJobPathFromNextDocumentPath(path string) string {
+	if !strings.HasPrefix(path, esclScanJobsPrefix) ||
+		!strings.HasSuffix(path, esclNextDocumentSuffix) {
+		return ""
+	}
+
+	jobPath := strings.TrimSuffix(path, esclNextDocumentSuffix)
+	if !esclJobPathValid(jobPath) {
+		return ""
+	}
+
+	return jobPath
+}
+
+// esclJobPathValid reports if path is exactly /eSCL/ScanJobs/<id>.
+func esclJobPathValid(path string) bool {
+	if !strings.HasPrefix(path, esclScanJobsPrefix) {
+		return false
+	}
+
+	id := strings.TrimPrefix(path, esclScanJobsPrefix)
+	return id != "" && !strings.Contains(id, "/")
+}
+
+// esclNeedsSynchronousExhaustedJobRelease reports if request requires
+// exhausted jobs to be released before forwarding it to the device.
+func esclNeedsSynchronousExhaustedJobRelease(r *http.Request) bool {
+	return r.Method == "POST" && r.URL.Path == esclScanJobsPath ||
+		r.Method == "GET" && r.URL.Path == esclScannerCapabilitiesPath
+}
+
+// esclNeedsPostResponseExhaustedJobRelease reports if request requires
+// exhausted jobs to be released after forwarding the device response.
+func esclNeedsPostResponseExhaustedJobRelease(r *http.Request) bool {
+	return r.Method == "GET" && r.URL.Path == esclScannerStatusPath
 }
 
 // Reject request with a error

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,181 @@
+/* ipp-usb - HTTP reverse proxy, backed by IPP-over-USB connection to device
+ *
+ * Copyright (C) 2020 and up by Alexander Pevzner (pzz@apevzner.com)
+ * See LICENSE for license terms and conditions
+ *
+ * Tests for HTTP proxy helpers
+ */
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestEsclJobPathFromNextDocumentPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{
+			path: "/eSCL/ScanJobs/urn:uuid:4509a320-0062-00f6-0121-0055a6372214/NextDocument",
+			want: "/eSCL/ScanJobs/urn:uuid:4509a320-0062-00f6-0121-0055a6372214",
+		},
+		{
+			path: "/eSCL/ScanJobs/job-1/NextDocument",
+			want: "/eSCL/ScanJobs/job-1",
+		},
+		{
+			path: "/eSCL/ScanJobs//NextDocument",
+			want: "",
+		},
+		{
+			path: "/eSCL/ScanJobs/job-1/doc/NextDocument",
+			want: "",
+		},
+		{
+			path: "/eSCL/ScanJobs/job-1",
+			want: "",
+		},
+		{
+			path: "/eSCL/ScannerStatus",
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		got := esclJobPathFromNextDocumentPath(test.path)
+		if got != test.want {
+			t.Errorf("esclJobPathFromNextDocumentPath(%q): expected %q, got %q",
+				test.path, test.want, got)
+		}
+	}
+}
+
+func TestEsclJobPathValid(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{
+			path: "/eSCL/ScanJobs/urn:uuid:4509a320-0062-00f6-0121-0055a6372214",
+			want: true,
+		},
+		{
+			path: "/eSCL/ScanJobs/job-1",
+			want: true,
+		},
+		{
+			path: "/eSCL/ScanJobs/",
+			want: false,
+		},
+		{
+			path: "/eSCL/ScanJobs/job-1/NextDocument",
+			want: false,
+		},
+		{
+			path: "/eSCL/ScannerStatus",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		got := esclJobPathValid(test.path)
+		if got != test.want {
+			t.Errorf("esclJobPathValid(%q): expected %v, got %v",
+				test.path, test.want, got)
+		}
+	}
+}
+
+func TestEsclNeedsSynchronousExhaustedJobRelease(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		{
+			method: "GET",
+			path:   "/eSCL/ScannerStatus",
+			want:   false,
+		},
+		{
+			method: "GET",
+			path:   "/eSCL/ScannerCapabilities",
+			want:   true,
+		},
+		{
+			method: "POST",
+			path:   "/eSCL/ScanJobs",
+			want:   true,
+		},
+		{
+			method: "GET",
+			path:   "/eSCL/ScanJobs/job-1/NextDocument",
+			want:   false,
+		},
+		{
+			method: "DELETE",
+			path:   "/eSCL/ScanJobs/job-1",
+			want:   false,
+		},
+		{
+			method: "POST",
+			path:   "/eSCL/ScanJobs/job-1",
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		r, err := http.NewRequest(test.method,
+			"http://localhost"+test.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := esclNeedsSynchronousExhaustedJobRelease(r)
+		if got != test.want {
+			t.Errorf("esclNeedsSynchronousExhaustedJobRelease(%s %s): expected %v, got %v",
+				test.method, test.path, test.want, got)
+		}
+	}
+}
+
+func TestEsclNeedsPostResponseExhaustedJobRelease(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		{
+			method: "GET",
+			path:   "/eSCL/ScannerStatus",
+			want:   true,
+		},
+		{
+			method: "POST",
+			path:   "/eSCL/ScanJobs",
+			want:   false,
+		},
+		{
+			method: "GET",
+			path:   "/eSCL/ScanJobs/job-1/NextDocument",
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		r, err := http.NewRequest(test.method,
+			"http://localhost"+test.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := esclNeedsPostResponseExhaustedJobRelease(r)
+		if got != test.want {
+			t.Errorf("esclNeedsPostResponseExhaustedJobRelease(%s %s): expected %v, got %v",
+				test.method, test.path, test.want, got)
+		}
+	}
+}

--- a/ipp-usb.8
+++ b/ipp-usb.8
@@ -350,6 +350,10 @@ Some devices send buggy (malformed) IPP responses that violate IPP specification
 .br
 If \fBtrue\fR, the matching device's fax capability is ignored\.
 .IP "\(bu" 4
+\fBescl\-auto\-release = true | false\fR
+.br
+If \fBtrue\fR, ipp\-usb remembers an eSCL scan job after the device returns \fB404 Not Found\fR for \fBGET /eSCL/ScanJobs/<id>/NextDocument\fR\. If the client then asks for scanner status, ipp\-usb forwards that request first and releases the job afterwards\. If the client asks for scanner capabilities or tries to start another scan without deleting that job, ipp\-usb releases the job first by sending \fBDELETE /eSCL/ScanJobs/<id>\fR\. If the client sends its own \fBDELETE\fR after ipp\-usb already released the job, ipp\-usb responds with \fB200 OK\fR locally\.
+.IP "\(bu" 4
 \fBhttp\-XXX = YYY\fR
 .br
 Set XXX header of the HTTP requests forwarded to device to YYY\. If YYY is empty string, XXX header is removed\.

--- a/ipp-usb.8.md
+++ b/ipp-usb.8.md
@@ -438,6 +438,17 @@ The following parameters are defined:
    * `disable-fax = true | false`<br>
      If `true`, the matching device's fax capability is ignored.
 
+   * `escl-auto-release = true | false`<br>
+     If `true`, ipp-usb remembers an eSCL scan job after the device
+     returns `404 Not Found` for
+     `GET /eSCL/ScanJobs/<id>/NextDocument`. If the client then asks
+     for scanner status, ipp-usb forwards that request first and releases
+     the job afterwards. If the client asks for scanner capabilities or
+     tries to start another scan without deleting that job, ipp-usb releases
+     the job first by sending `DELETE /eSCL/ScanJobs/<id>`. If the client
+     sends its own `DELETE` after ipp-usb already released the job,
+     ipp-usb responds with `200 OK` locally.
+
    * `http-XXX = YYY`<br>
      Set XXX header of the HTTP requests forwarded to device to YYY.
      If YYY is empty string, XXX header is removed.

--- a/quirks.go
+++ b/quirks.go
@@ -39,6 +39,7 @@ const (
 	QuirkNmBlacklist             = "blacklist"
 	QuirkNmBuggyIppResponses     = "buggy-ipp-responses"
 	QuirkNmDisableFax            = "disable-fax"
+	QuirkNmEsclAutoRelease       = "escl-auto-release"
 	QuirkNmIgnoreIppStatus       = "ignore-ipp-status"
 	QuirkNmInitDelay             = "init-delay"
 	QuirkNmInitReset             = "init-reset"
@@ -60,6 +61,7 @@ var quirkParse = map[string]func(*Quirk) error{
 	QuirkNmBlacklist:             (*Quirk).parseBool,
 	QuirkNmBuggyIppResponses:     (*Quirk).parseQuirkBuggyIppRsp,
 	QuirkNmDisableFax:            (*Quirk).parseBool,
+	QuirkNmEsclAutoRelease:       (*Quirk).parseBool,
 	QuirkNmIgnoreIppStatus:       (*Quirk).parseBool,
 	QuirkNmInitDelay:             (*Quirk).parseDuration,
 	QuirkNmInitReset:             (*Quirk).parseQuirkResetMethod,
@@ -81,6 +83,7 @@ var quirkDefaultStrings = map[string]string{
 	QuirkNmBlacklist:             "false",
 	QuirkNmBuggyIppResponses:     "reject",
 	QuirkNmDisableFax:            "false",
+	QuirkNmEsclAutoRelease:       "false",
 	QuirkNmIgnoreIppStatus:       "false",
 	QuirkNmInitDelay:             "0",
 	QuirkNmInitReset:             "none",
@@ -462,6 +465,12 @@ func (quirks *Quirks) GetBuggyIppRsp() QuirkBuggyIppRsp {
 // taking the whole set into consideration.
 func (quirks *Quirks) GetDisableFax() bool {
 	return quirks.Get(QuirkNmDisableFax).Parsed.(bool)
+}
+
+// GetEsclAutoRelease returns effective "escl-auto-release" parameter,
+// taking the whole set into consideration.
+func (quirks *Quirks) GetEsclAutoRelease() bool {
+	return quirks.Get(QuirkNmEsclAutoRelease).Parsed.(bool)
 }
 
 // GetIgnoreIppStatus returns effective "ignore-ipp-status" parameter,

--- a/quirks_test.go
+++ b/quirks_test.go
@@ -368,6 +368,17 @@ func TestQuirksLookup(t *testing.T) {
 
 		{
 			model: "Unknown Device",
+			param: QuirkNmEsclAutoRelease,
+			get: func(quirks *Quirks) interface{} {
+				return quirks.GetEsclAutoRelease()
+			},
+			match:  "*",
+			value:  false,
+			origin: "default",
+		},
+
+		{
+			model: "Unknown Device",
 			param: QuirkNmIgnoreIppStatus,
 			get: func(quirks *Quirks) interface{} {
 				return quirks.GetIgnoreIppStatus()


### PR DESCRIPTION
Implements a new quirk for client applications that do not release scan jobs upon completion. I saw this issue on my Kyocera ECOSYS M5521cdw running both a very out of date and the latest firmware. I used both the ipp-usb package from Debian 13 and a build from latest release. All failed the same.

Basically, I saw two types of clients: those that release the job upon completion and those that probably expect the scanner to do it on their behalf. What happens with clients that don't release the job is that the scanner waits for a couple of minutes until changing the status from Processing to Idle and no new jobs can be triggered until this timeout happens.

What this quirk does: When NextDocument returns 404, ipp-usb records the exhausted job and later issues a synthetic DELETE /eSCL/ScanJobs/<id> at safe workflow points, preventing stale jobs from leaving the scanner busy. The implementation preserves clients that send their own DELETE by returning local 200 OK for already released jobs, and avoids blocking post-404 ScannerStatus flow. During the implementation I saw that Scan on Windows returns a paper jammed error if the DELETE request is triggered too early even though the flatbed scanner is guaranteed not to have a paper jam. Ran into a NAPS2 race condition when ScannerStatus is forwarded at the same time as a DELETE. So the synthetic DELETE is tracked and workflow requests like ScannerCapabilities and ScanJobs wait until this cleanup is done.

Do note that I am not a Go developer so if any of this reads like slop, it is because I used Codex. Feel free to roast the clanker's code. I've done plenty of manual QA though going through all known failure scenarios and trying to trigger race conditions.

Now for the details on how I scoped this work. I ran into well behaved clients:

- Mopria Scan on Android. This M5521cdw is a Mopria certified device. An argument can be made that this is the correct client implementation behaviour.
- Document Scanner on Ubuntu (I believe this comes from GNOME) for one of its two eSCL backend implementation. The good implementation is either available by default when only one printer endpoint is detected. When multiple printers are detected, it shows as airscan:e0:Kyocera ECOSYS M5521cdw.

I couldn't test on Mac because mine broke, but I never had a problem with the macOS Scanner application, whereas with this quirk enabled the Scan application from Windows is finally reliable for me. I got stuck to using Kyocera Print Center (which doesn't work with ipp-usb) for ages.

A successful transaction looks like:

```
POST /eSCL/ScanJobs                   -> 201
GET  /eSCL/ScanJobs/<id>/NextDocument -> 200 (PDF/image)
GET  /eSCL/ScanJobs/<id>/NextDocument -> 404 (no more pages)
DELETE /eSCL/ScanJobs/<id>            -> 200

next POST /eSCL/ScanJobs is successful
```

Badly behaved (read: naïve) clients do not trigger this DELETE call:

- Scan application on Windows
- NAPS2
- Document Scanner on Ubuntu when a race condition happens and the second eSCL backend is in use. Shows as escl:http://{IP}:60000 when detected. Shows up rarely as most of the time the other backend is used.

I haven't traced Scan on Windows as the error was similar to NAPS2: scanner busy.

Here I've seen two failure modes:

NAPS2:

```
POST /eSCL/ScanJobs                   -> 201
GET  /eSCL/ScanJobs/<id>/NextDocument -> 200 (PDF/image)
GET  /eSCL/ScanJobs/<id>/NextDocument -> 404 (no more pages)
(no DELETE)
GET /eSCL/ScannerStatus               -> 200 (status: Processing)
returns "scanner busy" error and gives up
```

Document Scanner on Ubuntu with "escl:" backend:

```
POST /eSCL/ScanJobs                   -> 201
GET  /eSCL/ScanJobs/<id>/NextDocument -> 200 (PDF/image)
GET  /eSCL/ScanJobs/<id>/NextDocument -> 404 (no more pages)
(no DELETE)
POST /eSCL/ScanJobs                   -> 503
retries until successful for a couple of minutes until status turns to Idle
```

It doesn't return an error, just hammers the /eSCL/ScanJobs endpoint until the job is accepted successfully, but it wastes a couple of minutes for the job timeout to trigger.